### PR TITLE
Update README to remove stars and forks badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,7 @@
 
 代码已完全开源,请各位开发者务必遵守基本的操守,请勿fork代码修改功能引导他人部署后盗取他人账号,勿以恶小而为之,勿以善小而不为.
 
-![GitHub stars](https://img.shields.io/github/stars/doubleDimple/oci-start)
-![GitHub forks](https://img.shields.io/github/forks/doubleDimple/oci-start)
+
 ![GitHub issues](https://img.shields.io/github/issues/doubleDimple/oci-start)
 ![License](https://img.shields.io/github/license/doubleDimple/oci-start)
 [![GitHub stars](https://img.shields.io/github/stars/doubleDimple/oci-start?style=flat-square&logo=github)](https://github.com/doubleDimple/oci-start)


### PR DESCRIPTION
Removed GitHub stars and forks badges from README.