### PR TITLE
fix: 启用 IPv6 应在实例 VNIC 实际所在的子网上进行

### DIFF
--- a/oci-server/src/main/java/com/doubledimple/ociserver/service/oracle/impl/OracleInstanceServiceImpl.java
+++ b/oci-server/src/main/java/com/doubledimple/ociserver/service/oracle/impl/OracleInstanceServiceImpl.java
@@ -489,18 +489,20 @@ public class OracleInstanceServiceImpl implements OracleInstanceService {
         String compartmentId = provider.getTenantId();
 
         try (VirtualNetworkClient virtualNetworkClient = VirtualNetworkClient.builder().build(provider);
-             IdentityClient identityClient = IdentityClient.builder().build(provider);
              ComputeClient computeClient = ComputeClient.builder().build(provider)) {
 
             // Get VNIC associated with instance
             Vnic vnic = OciIpv6Utils.getVnic(computeClient, virtualNetworkClient, instanceId, compartmentId);
 
+            // 必须使用实例 VNIC 真实所在的子网/VCN，否则会把 IPv6 段加到别的子网，导致 "ipv6 not enabled in this subnet"
+            Subnet subnet = OciIpv6Utils.getSubnetById(virtualNetworkClient, vnic.getSubnetId());
+            Vcn vcn = OciIpv6Utils.getVcnById(virtualNetworkClient, subnet.getVcnId());
+
             // Ensure VCN has IPv6 enabled
-            Vcn vcn = OciIpv6Utils.ensureVcnWithIpv6(virtualNetworkClient, compartmentId);
+            vcn = OciIpv6Utils.ensureVcnWithIpv6(virtualNetworkClient, vcn);
 
             // Ensure subnet has IPv6 CIDR block
-            Subnet subnet = OciIpv6Utils.ensureSubnetWithIpv6(
-                    virtualNetworkClient, identityClient, compartmentId, vcn.getId());
+            OciIpv6Utils.ensureSubnetWithIpv6(virtualNetworkClient, subnet, vcn);
 
             // Ensure IPv6 internet gateway exists
             OciIpv6Utils.ensureIpv6InternetGateway(virtualNetworkClient, compartmentId, vcn.getId());

--- a/oci-server/src/main/java/com/doubledimple/ociserver/utils/oracle/OciIpv6Utils.java
+++ b/oci-server/src/main/java/com/doubledimple/ociserver/utils/oracle/OciIpv6Utils.java
@@ -3,16 +3,12 @@ package com.doubledimple.ociserver.utils.oracle;
 import com.oracle.bmc.core.*;
 import com.oracle.bmc.core.model.*;
 import com.oracle.bmc.core.requests.*;
-import com.oracle.bmc.identity.IdentityClient;
-import com.oracle.bmc.identity.model.AvailabilityDomain;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
 
 import java.util.ArrayList;
 import java.util.List;
-
-import static com.doubledimple.ociserver.service.oracle.OracleCloudService.getFirstAvailabilityDomain;
 
 /**
  * Utility class for Oracle Cloud Infrastructure IPv6 operations
@@ -67,10 +63,8 @@ public class OciIpv6Utils {
     /**
      * Ensures that the VCN has IPv6 enabled
      */
-    public static Vcn ensureVcnWithIpv6(VirtualNetworkClient virtualNetworkClient, String compartmentId) {
-        log.debug("Ensuring VCN with IPv6 in compartment: {}", compartmentId);
-
-        Vcn vcn = getOrCreateVcn(virtualNetworkClient, compartmentId);
+    public static Vcn ensureVcnWithIpv6(VirtualNetworkClient virtualNetworkClient, Vcn vcn) {
+        log.debug("Ensuring VCN with IPv6: {}", vcn.getId());
 
         if (vcn.getIpv6CidrBlocks() == null || vcn.getIpv6CidrBlocks().isEmpty()) {
             log.debug("No IPv6 CIDR blocks found for VCN. Adding IPv6 CIDR...");
@@ -94,18 +88,12 @@ public class OciIpv6Utils {
      * Ensures subnet has IPv6 CIDR block
      */
     public static Subnet ensureSubnetWithIpv6(VirtualNetworkClient virtualNetworkClient,
-                                              IdentityClient identityClient,
-                                              String compartmentId,
-                                              String vcnId) {
-        log.debug("Ensuring subnet with IPv6 in VCN: {}", vcnId);
-
-        Subnet subnet = getOrCreateSubnet(virtualNetworkClient, identityClient, compartmentId, vcnId);
+                                              Subnet subnet,
+                                              Vcn vcn) {
+        log.debug("Ensuring subnet with IPv6: {}", subnet.getId());
 
         if (StringUtils.isEmpty(subnet.getIpv6CidrBlock())) {
             log.debug("No IPv6 CIDR block found for subnet. Adding IPv6 CIDR...");
-
-            GetVcnRequest getVcnRequest = GetVcnRequest.builder().vcnId(vcnId).build();
-            Vcn vcn = virtualNetworkClient.getVcn(getVcnRequest).getVcn();
 
             List<String> ipv6CidrBlocks = vcn.getIpv6CidrBlocks();
             if (ipv6CidrBlocks == null || ipv6CidrBlocks.isEmpty()) {
@@ -179,77 +167,6 @@ public class OciIpv6Utils {
     }
 
     // Private helper methods
-
-    private static Vcn getOrCreateVcn(VirtualNetworkClient virtualNetworkClient, String compartmentId) {
-        ListVcnsRequest listRequest = ListVcnsRequest.builder()
-                .compartmentId(compartmentId)
-                .limit(10)
-                .build();
-
-        List<Vcn> vcns = virtualNetworkClient.listVcns(listRequest).getItems();
-
-        if (!vcns.isEmpty()) {
-            log.debug("Using existing VCN: {}", vcns.get(0).getId());
-            return vcns.get(0);
-        }
-
-        log.debug("Creating new VCN in compartment: {}", compartmentId);
-
-        CreateVcnDetails createDetails = CreateVcnDetails.builder()
-                .compartmentId(compartmentId)
-                .cidrBlock("10.0.0.0/16")
-                .displayName("IPv6-VCN-" + System.currentTimeMillis())
-                .isIpv6Enabled(true)
-                .build();
-
-        CreateVcnRequest createRequest = CreateVcnRequest.builder()
-                .createVcnDetails(createDetails)
-                .build();
-
-        Vcn vcn = virtualNetworkClient.createVcn(createRequest).getVcn();
-        log.debug("Created new VCN with ID: {}", vcn.getId());
-
-        return vcn;
-    }
-
-    private static Subnet getOrCreateSubnet(VirtualNetworkClient virtualNetworkClient,
-                                            IdentityClient identityClient,
-                                            String compartmentId,
-                                            String vcnId) {
-        ListSubnetsRequest listRequest = ListSubnetsRequest.builder()
-                .compartmentId(compartmentId)
-                .vcnId(vcnId)
-                .limit(10)
-                .build();
-
-        List<Subnet> subnets = virtualNetworkClient.listSubnets(listRequest).getItems();
-
-        if (!subnets.isEmpty()) {
-            log.debug("Using existing subnet: {}", subnets.get(0).getId());
-            return subnets.get(0);
-        }
-
-        log.debug("Creating new subnet in VCN: {}", vcnId);
-
-        AvailabilityDomain availabilityDomain = getFirstAvailabilityDomain(identityClient, compartmentId);
-
-        CreateSubnetDetails createDetails = CreateSubnetDetails.builder()
-                .compartmentId(compartmentId)
-                .vcnId(vcnId)
-                .availabilityDomain(availabilityDomain.getName())
-                .cidrBlock("10.0.0.0/24")
-                .displayName("IPv6-Subnet-" + System.currentTimeMillis())
-                .build();
-
-        CreateSubnetRequest createRequest = CreateSubnetRequest.builder()
-                .createSubnetDetails(createDetails)
-                .build();
-
-        Subnet subnet = virtualNetworkClient.createSubnet(createRequest).getSubnet();
-        log.debug("Created new subnet with ID: {}", subnet.getId());
-
-        return subnet;
-    }
 
     private static String findOrCreateIpv6Gateway(VirtualNetworkClient virtualNetworkClient,
                                                   String compartmentId,
@@ -453,6 +370,22 @@ public class OciIpv6Utils {
         log.debug("Found VNIC with ID: {}", vnic.getId());
 
         return vnic;
+    }
+
+    /**
+     * Gets a subnet by its OCID
+     */
+    public static Subnet getSubnetById(VirtualNetworkClient virtualNetworkClient, String subnetId) {
+        GetSubnetRequest request = GetSubnetRequest.builder().subnetId(subnetId).build();
+        return virtualNetworkClient.getSubnet(request).getSubnet();
+    }
+
+    /**
+     * Gets a VCN by its OCID
+     */
+    public static Vcn getVcnById(VirtualNetworkClient virtualNetworkClient, String vcnId) {
+        GetVcnRequest request = GetVcnRequest.builder().vcnId(vcnId).build();
+        return virtualNetworkClient.getVcn(request).getVcn();
     }
 
 }


### PR DESCRIPTION
## 问题
`POST /oci/enableIpv6` 有时会报错 `ipv6 not enabled in this subnet`。

## 根因
`OracleInstanceServiceImpl.enableOrRefreshIpv6` 的流程里「加 IPv6 段的子网」和「创建 IPv6 的 VNIC」用的不是同一个子网:

- `getVnic()` 取到的是实例**真实的 VNIC**(位于子网 A)
- `ensureVcnWithIpv6` → `getOrCreateVcn` 用 `vcns.get(0)` 取 compartment 里的**第一个 VCN**
- `ensureSubnetWithIpv6` → `getOrCreateSubnet` 用 `subnets.get(0)` 取**第一个子网**(子网 B),并把 IPv6 CIDR 加到子网 B
- 最后在**子网 A 的 VNIC** 上 `createIpv6`

当子网 A ≠ 子网 B(账号有多个 VCN 或多个子网)时,VNIC 所在子网没有 IPv6 段,OCI 就报 `ipv6 not enabled in this subnet`。只有单 VCN + 单子网的账号恰好 A==B,所以表现为「有时候」才失败。

## 改动
- 从 VNIC 自身推导子网与 VCN:`vnic.getSubnetId()` → `getSubnetById()` → `subnet.getVcnId()` → `getVcnById()`,保证加段的子网就是 VNIC 所在子网
- `ensureVcnWithIpv6(client, Vcn)`、`ensureSubnetWithIpv6(client, Subnet, Vcn)` 改为接收真实对象
- 删除不再使用的 `getOrCreateVcn` / `getOrCreateSubnet`(实例已存在,其 VCN/子网必然存在,无需再 list/create)
- 移除该方法里多余的 `IdentityClient`

## 测试
- [x] `mvn -pl oci-server -am compile` 编译通过(本环境仅有 JDK21,仓库 Lombok 1.18.24 不支持 JDK21,故临时用兼容版本验证编译,**仓库内 Lombok 版本未改动**)
- [ ] 在「多 VCN / 多子网」的账号上实测 `/oci/enableIpv6`,确认不再报 `ipv6 not enabled in this subnet`
- [ ] 确认新建的 IPv6 地址成功绑定到实例 VNIC 所在子网,实例 reboot 后可用

---