### PR TITLE
fix: 租户管理列表同一行内容垂直对齐

### DIFF
--- a/oci-server/src/main/resources/static/css/app/tenant-list.css
+++ b/oci-server/src/main/resources/static/css/app/tenant-list.css
@@ -1187,6 +1187,12 @@ textarea::placeholder { color: var(--text-secondary); }
     vertical-align: middle;
 }
 
+/* 单元格内的行内元素（徽标/胶囊/按钮/链接）默认按基线对齐，会与纯文本错位，
+   这里统一改为按中线对齐，保证同一行内容在一条水平线上 */
+.table td > * {
+    vertical-align: middle;
+}
+
 /* 小按钮样式 */
 .btn-sm {
     padding: 2px 6px;


### PR DESCRIPTION
## 问题
租户管理(`tenant_list`)列表里,同一行的单元格内容没有在一条水平线上:纯文本(序号、自定义名称、账号成本、主区域、创建时间)偏高,橙色「创建实例」按钮偏低,胶囊徽标(存活天数/开机任务/是否多区/账号类型/账号状态)大致居中,三者错位。

## 根因
`.table td` 已经设了 `vertical-align: middle`(单元格盒子垂直居中),但单元格内部的**行内元素**(`<a>` 链接、`<span>` 胶囊、`.btn-boot` 按钮)默认是 `vertical-align: baseline`,会按文字基线对齐:
- 较高的按钮基线靠下 → 整体偏低
- 纯文本/链接按基线 → 偏高
- 胶囊是 `inline-flex` → 又大致居中

于是同一行高低不齐。

## 改动
在 `oci-server/.../static/css/app/tenant-list.css` 补一条规则,让单元格内行内元素也按中线对齐:

```css
.table td > * {
    vertical-align: middle;
}
```

仅新增 6 行(含注释),不改结构、不动其它样式。

## 验证
用**真实的 `tenant-list.css`** + 真实表格结构在 Chromium(Playwright)里渲染复现并验证。红色虚线为每行垂直中线:
- 修复前:内容明显高低不齐(按钮偏低、文本偏高)
- 修复后:所有内容落在同一中线上

(渲染对比截图已在对话中提供。)

---