### PR TITLE
fix: 流量统计任务改为事件异步执行,修复小机器漏跑

### DIFF
--- a/oci-server/src/main/java/com/doubledimple/ociserver/config/ThreadPoolConfig.java
+++ b/oci-server/src/main/java/com/doubledimple/ociserver/config/ThreadPoolConfig.java
@@ -347,6 +347,23 @@ public class ThreadPoolConfig {
         return executor;
     }
 
+    /**
+     * 流量统计专用线程池：单线程、几乎不排队、忙时直接丢弃。
+     * 保证长耗时的流量任务既不和其它事件抢线程，也不会因触发堆积而多轮并行。
+     */
+    @Bean(name = "trafficExecutor")
+    public ThreadPoolTaskExecutor trafficExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(1);
+        executor.setMaxPoolSize(1);
+        executor.setQueueCapacity(1);
+        executor.setThreadNamePrefix("traffic-pool-");
+        executor.setRejectedExecutionHandler(new ThreadPoolExecutor.DiscardPolicy());
+        executor.setWaitForTasksToCompleteOnShutdown(false);
+        executor.initialize();
+        return executor;
+    }
+
     @Bean(name = "ociApiExecutor")
     public ThreadPoolExecutor ociApiExecutor() {
         int cpu = Runtime.getRuntime().availableProcessors();

--- a/oci-server/src/main/java/com/doubledimple/ociserver/config/event/InstanceTrafficCheckEvent.java
+++ b/oci-server/src/main/java/com/doubledimple/ociserver/config/event/InstanceTrafficCheckEvent.java
@@ -1,0 +1,14 @@
+package com.doubledimple.ociserver.config.event;
+
+import org.springframework.context.ApplicationEvent;
+
+/**
+ * 流量统计触发事件
+ * 由 Quartz 的 InstanceTrafficJob 发布，真正的重活由异步监听器处理，
+ * 避免长耗时任务占用 Quartz 工作线程导致触发被挡掉 / misfire。
+ */
+public class InstanceTrafficCheckEvent extends ApplicationEvent {
+    public InstanceTrafficCheckEvent(Object source) {
+        super(source);
+    }
+}

--- a/oci-server/src/main/java/com/doubledimple/ociserver/config/event/InstanceTrafficCheckEventListener.java
+++ b/oci-server/src/main/java/com/doubledimple/ociserver/config/event/InstanceTrafficCheckEventListener.java
@@ -1,0 +1,48 @@
+package com.doubledimple.ociserver.config.event;
+
+import com.doubledimple.ociserver.config.task.InstanceTrafficTask;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.Resource;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * 流量统计异步监听器
+ * 在专用线程池 trafficExecutor 上执行，并用 running 标志保证同一时刻只有一轮在跑：
+ * 上一轮还没结束时，本轮直接跳过（小机器上单轮耗时长属正常），避免重活并行把内存压垮。
+ */
+@Component
+@Slf4j
+public class InstanceTrafficCheckEventListener {
+
+    @Resource
+    private InstanceTrafficTask instanceTrafficTask;
+
+    private final AtomicBoolean running = new AtomicBoolean(false);
+
+    @Async("trafficExecutor")
+    @EventListener
+    public void handle(InstanceTrafficCheckEvent event) {
+        if (!running.compareAndSet(false, true)) {
+            log.warn("[流量预警] 上一轮尚未结束，跳过本轮触发");
+            return;
+        }
+        String traceId = UUID.randomUUID().toString().replace("-", "");
+        MDC.put("traceId", traceId);
+        long start = System.currentTimeMillis();
+        try {
+            instanceTrafficTask.updateInstanceTraffic();
+        } catch (Exception e) {
+            log.error("执行流量统计任务失败，原因: {}", e.getMessage(), e);
+        } finally {
+            running.set(false);
+            log.debug("[流量预警] 本轮结束，耗时 {} ms", System.currentTimeMillis() - start);
+            MDC.clear();
+        }
+    }
+}

--- a/oci-server/src/main/java/com/doubledimple/ociserver/config/task/InstanceTrafficTask.java
+++ b/oci-server/src/main/java/com/doubledimple/ociserver/config/task/InstanceTrafficTask.java
@@ -9,9 +9,12 @@ import com.doubledimple.ocicommon.enums.oci.TrafficPeriod;
 import com.doubledimple.ociserver.pojo.enums.MessageEnum;
 import com.doubledimple.ociserver.service.message.factory.MessageFactory;
 import com.doubledimple.ociserver.service.oracle.OracleInstanceService;
+import com.doubledimple.ociserver.utils.oracle.OciUtils;
 import com.doubledimple.ociserver.utils.oracle.TrafficMetricsUtils;
 import com.doubledimple.ociserver.utils.oracle.vnic.VnicCreationResult;
 import com.doubledimple.ociserver.utils.oracle.vnic.VnicManagementUtils;
+import com.oracle.bmc.auth.SimpleAuthenticationDetailsProvider;
+import com.oracle.bmc.monitoring.MonitoringClient;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
@@ -45,6 +48,9 @@ public class InstanceTrafficTask {
     @Resource
     private MessageFactory messageFactory;
 
+    /** 单轮最长时间预算，超出后提前结束，避免拖到下一轮触发（间隔 30 分钟） */
+    private static final long RUN_BUDGET_MS = 25 * 60 * 1000L;
+
     /**
      * 定时任务入口
      * 每次执行都实时查询 OCI Monitoring
@@ -53,7 +59,12 @@ public class InstanceTrafficTask {
         log.debug("[流量预警] 开始执行实时任务...");
         List<Tenant> tenants = tenantRepository.findAll();
 
+        long deadline = System.currentTimeMillis() + RUN_BUDGET_MS;
         for (Tenant tenant : tenants) {
+            if (System.currentTimeMillis() > deadline) {
+                log.warn("[流量预警] 本轮已超时间预算 {} 分钟，提前结束，剩余租户下轮处理", RUN_BUDGET_MS / 60000);
+                break;
+            }
             Optional<TrafficAlert> alertOpt = trafficAlertRepository.findByTenantId(tenant.getId());
             if (alertOpt.isPresent() && alertOpt.get().getStatisticsEnabled()) {
                 try {
@@ -93,42 +104,47 @@ public class InstanceTrafficTask {
                 .filter(v -> v != null && v.getVnicId() != null && !v.getVnicId().trim().isEmpty())
                 .collect(Collectors.groupingBy(VnicCreationResult::getInstanceId, LinkedHashMap::new, Collectors.toList()));
 
-        // 4. 遍历每个实例的 VNIC，统计出站流量
-        for (Map.Entry<String, List<VnicCreationResult>> entry : vnicsByInstance.entrySet()) {
-            String instanceId = entry.getKey();
-            List<VnicCreationResult> vnics = entry.getValue();
+        // 4. 复用同一个 MonitoringClient（带超时）查询每个实例的出站流量
+        SimpleAuthenticationDetailsProvider provider = OciUtils.getProvider(tenant);
+        String compartmentId = provider.getTenantId();
+        try (MonitoringClient monitoringClient = TrafficMetricsUtils.buildClient(provider)) {
+            for (Map.Entry<String, List<VnicCreationResult>> entry : vnicsByInstance.entrySet()) {
+                String instanceId = entry.getKey();
+                List<VnicCreationResult> vnics = entry.getValue();
 
-            if (vnics.isEmpty()) {
-                log.warn("租户 [{}] 实例 [{}] 未找到有效 VNIC ID", tenant.getTenancy(), instanceId);
-                continue;
+                if (vnics.isEmpty()) {
+                    log.warn("租户 [{}] 实例 [{}] 未找到有效 VNIC ID", tenant.getTenancy(), instanceId);
+                    continue;
+                }
+
+                // 去重（如果有重复 VNIC ID）
+                List<VnicCreationResult> uniqueVnics = vnics.stream()
+                        .collect(Collectors.collectingAndThen(
+                                Collectors.toMap(
+                                        VnicCreationResult::getVnicId,
+                                        v -> v,
+                                        (existing, replacement) -> existing,
+                                        LinkedHashMap::new
+                                ),
+                                map -> new ArrayList<>(map.values())
+                        ));
+
+                double instanceEgress = TrafficMetricsUtils.getInstanceTrafficTotal(
+                        monitoringClient,
+                        compartmentId,
+                        uniqueVnics,
+                        true,
+                        startTime,
+                        endTime,
+                        TrafficPeriod.ONE_DAY
+                );
+
+                String instanceName = uniqueVnics.get(0).getInstanceName();
+                log.debug("租户 [{}] 实例 [{}] VNIC 数:{} 出站流量:{} bytes",
+                        tenant.getTenancy(), instanceName, uniqueVnics.size(), instanceEgress);
+
+                totalTenantEgress += instanceEgress;
             }
-
-            // 去重（如果有重复 VNIC ID）
-            List<VnicCreationResult> uniqueVnics = vnics.stream()
-                    .collect(Collectors.collectingAndThen(
-                            Collectors.toMap(
-                                    VnicCreationResult::getVnicId,
-                                    v -> v,
-                                    (existing, replacement) -> existing,
-                                    LinkedHashMap::new
-                            ),
-                            map -> new ArrayList<>(map.values())
-                    ));
-
-            double instanceEgress = TrafficMetricsUtils.getInstanceTrafficTotal(
-                    tenant,
-                    uniqueVnics,
-                    true,
-                    startTime,
-                    endTime,
-                    TrafficPeriod.ONE_DAY
-            );
-
-            String instanceName = uniqueVnics.get(0).getInstanceName();
-            log.debug("租户 [{}] 实例 [{}] VNIC 数:{} 出站流量:{} bytes",
-                    tenant.getTenancy(), instanceName, uniqueVnics.size(), instanceEgress);
-
-            totalTenantEgress += instanceEgress;
         }
 
         // 5. 判断是否超过阈值

--- a/oci-server/src/main/java/com/doubledimple/ociserver/job/InstanceTrafficJob.java
+++ b/oci-server/src/main/java/com/doubledimple/ociserver/job/InstanceTrafficJob.java
@@ -1,41 +1,29 @@
 package com.doubledimple.ociserver.job;
 
-import com.doubledimple.ociserver.config.task.InstanceTrafficTask;
+import com.doubledimple.ociserver.config.event.InstanceTrafficCheckEvent;
 import lombok.extern.slf4j.Slf4j;
-import org.quartz.DisallowConcurrentExecution;
 import org.quartz.Job;
 import org.quartz.JobExecutionContext;
-import org.quartz.JobExecutionException;
-import org.slf4j.MDC;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Component;
 
 import javax.annotation.Resource;
-import java.util.UUID;
 
 /**
  * 实例流量统计任务Job
+ * 只负责发布事件后立即返回，真正的统计在异步监听器里执行，
+ * 避免长耗时占用 Quartz 工作线程导致触发被挡掉 / misfire（小机器上尤为明显）。
  */
 @Slf4j
 @Component
-@DisallowConcurrentExecution
 public class InstanceTrafficJob implements Job {
 
     @Resource
-    private InstanceTrafficTask instanceTrafficTask;
-
+    private ApplicationEventPublisher eventPublisher;
 
     @Override
-    public void execute(JobExecutionContext context) throws JobExecutionException {
-        String traceId = UUID.randomUUID().toString().replace("-", "");
-        MDC.put("traceId", traceId);
-        log.debug("开始执行流量统计任务.....");
-        try {
-            instanceTrafficTask.updateInstanceTraffic();
-        } catch (Exception e) {
-            log.error("执行流量统计任务失败，原因: {}", e.getMessage(), e);
-            throw new JobExecutionException(e);
-        }finally {
-            MDC.clear();
-        }
+    public void execute(JobExecutionContext context) {
+        log.debug("触发流量统计任务，发布异步事件...");
+        eventPublisher.publishEvent(new InstanceTrafficCheckEvent(this));
     }
 }

--- a/oci-server/src/main/java/com/doubledimple/ociserver/utils/oracle/TrafficMetricsUtils.java
+++ b/oci-server/src/main/java/com/doubledimple/ociserver/utils/oracle/TrafficMetricsUtils.java
@@ -3,6 +3,7 @@ package com.doubledimple.ociserver.utils.oracle;
 import com.doubledimple.dao.entity.Tenant;
 import com.doubledimple.ocicommon.enums.oci.TrafficPeriod;
 import com.doubledimple.ociserver.utils.oracle.vnic.VnicCreationResult;
+import com.oracle.bmc.ClientConfiguration;
 import com.oracle.bmc.auth.SimpleAuthenticationDetailsProvider;
 import com.oracle.bmc.monitoring.MonitoringClient;
 import com.oracle.bmc.monitoring.model.AggregatedDatapoint;
@@ -78,20 +79,29 @@ public class TrafficMetricsUtils {
     }
 
     /**
-     * 查询实例下所有 VNIC 的总流量
+     * 构建带连接/读超时的 MonitoringClient，避免单次调用无限期挂起拖垮整个任务
      */
-    public static double getInstanceTrafficTotal(Tenant tenant,
+    public static MonitoringClient buildClient(SimpleAuthenticationDetailsProvider provider) {
+        ClientConfiguration config = ClientConfiguration.builder()
+                .connectionTimeoutMillis(10_000)
+                .readTimeoutMillis(30_000)
+                .build();
+        return MonitoringClient.builder().configuration(config).build(provider);
+    }
+
+    /**
+     * 查询实例下所有 VNIC 的总流量（复用调用方传入的 MonitoringClient，避免每实例新建客户端）
+     */
+    public static double getInstanceTrafficTotal(MonitoringClient client,
+                                                 String compartmentId,
                                                  List<VnicCreationResult> vnics,
                                                  boolean egress,
                                                  Date startTime,
                                                  Date endTime,
                                                  TrafficPeriod period) {
-        SimpleAuthenticationDetailsProvider provider = OciUtils.getProvider(tenant);
         double total = 0D;
-        try (MonitoringClient client = MonitoringClient.builder().build(provider)) {
-            for (VnicCreationResult vnic : vnics) {
-                total += getVnicTrafficTotal(client, provider.getTenantId(), vnic.getVnicId(), egress, startTime, endTime, period);
-            }
+        for (VnicCreationResult vnic : vnics) {
+            total += getVnicTrafficTotal(client, compartmentId, vnic.getVnicId(), egress, startTime, endTime, period);
         }
         return total;
     }


### PR DESCRIPTION
## 问题
定时任务 `InstanceTrafficTask`（流量统计/预警)**有时不执行,尤其在小机器上**。

## 根因
- `InstanceTrafficJob` 是 Quartz Job,标了 `@DisallowConcurrentExecution`,**在 Quartz 工作线程里同步**调用 `updateInstanceTraffic()`,跑完一整轮(遍历所有租户 → `listAllVnicsForTenant` → 每个实例 `getInstanceTrafficTotal`,且**每个实例都新建 `MonitoringClient`、逐 VNIC 同步查 OCI Monitoring、无超时**)。
- 单轮耗时随账号规模线性增长。**小机器**(CPU/内存/网络紧、GC 停顿多)上耗时显著放大,常常逼近甚至超过 cron 间隔(`0 0/30 * * * ?` = **每 30 分钟**;代码注释误写"每5分钟")。
- 叠加 `@DisallowConcurrentExecution` + JDBC job store 默认 misfire 阈值(60s)+ 默认 misfire 策略,上一轮没跑完时,这一轮触发被挡/misfire → **被跳过**。再加上 Quartz 线程池(默认 10)被高频任务(`createInstanceJob` 每 6s、心跳每 15s 等)占用,触发时抢不到线程也会 misfire。表现就是"有时候不执行"、且偏向小机器。

## 改动(Spring event 异步化 + 三项配套)
- **解耦**:`InstanceTrafficJob.execute()` 只 `publishEvent(InstanceTrafficCheckEvent)` 后**立即返回**,Quartz 工作线程毫秒级释放,不再被长任务占用、不再 misfire;去掉已无意义的 `@DisallowConcurrentExecution`。
- **异步执行 + 不重叠**:新增 `@Async("trafficExecutor") @EventListener` 执行重活;新增**专用单线程池** `trafficExecutor`(core1/max1/queue1/`DiscardPolicy`)+ 监听器内 `AtomicBoolean running` 守卫 → **忙时直接跳过本轮**,避免多轮并行把小机器内存压垮,也不会饿死其它 `@Async` 事件。
- **收紧单轮耗时**:`TrafficMetricsUtils` 新增 `buildClient`(连接超时 10s / 读超时 30s),`getInstanceTrafficTotal` 改为复用调用方传入的 `MonitoringClient`;`InstanceTrafficTask` **每租户复用一个 client**(原来每实例新建),并加**单轮时间预算**(25 分钟,超出提前结束,剩余租户下轮处理),防止个别 OCI 调用挂死拖垮整轮。

## 效果
Quartz 不再被拖 → 重活异步、**不重叠、有超时、不饿死别人** → 小机器上要么按时跑、要么"忙就跳过这一轮"(可预期、有日志),不会再莫名其妙永久漏跑。

## 测试
- [x] `mvn -pl oci-server -am compile` 编译通过(本环境仅 JDK21,仓库 Lombok 1.18.24 不兼容 JDK21,临时用兼容版本验证编译,**仓库内 Lombok 版本未改动**)。
- [ ] 部署后观察:`[流量预警] 开始执行实时任务` / `本轮结束 耗时 X ms` 日志;小机器上确认按 30 分钟节奏触发,忙时出现"跳过本轮"而非长期缺失。
- [ ] 确认流量超限告警/自动关机逻辑不受影响。

---
