### PR TITLE
fix: 短间隔定时任务异步派发+单飞守卫,避免阻塞 Quartz 线程

### DIFF
--- a/oci-server/src/main/java/com/doubledimple/ociserver/config/ThreadPoolConfig.java
+++ b/oci-server/src/main/java/com/doubledimple/ociserver/config/ThreadPoolConfig.java
@@ -159,6 +159,24 @@ public class ThreadPoolConfig {
     }
 
     /**
+     * 短间隔定时任务的异步执行线程池（配合 AsyncJobRunner）。
+     * 单飞由 AsyncJobRunner 的守卫保证；这里用 DiscardPolicy，线程占满时直接丢弃本次触发，
+     * 绝不回灌到 Quartz 调度线程（不要用 CallerRunsPolicy）。
+     */
+    @Bean(name = "jobExecutor")
+    public ThreadPoolTaskExecutor jobExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(3);
+        executor.setMaxPoolSize(3);
+        executor.setQueueCapacity(2);
+        executor.setThreadNamePrefix("job-async-");
+        executor.setRejectedExecutionHandler(new ThreadPoolExecutor.DiscardPolicy());
+        executor.setWaitForTasksToCompleteOnShutdown(false);
+        executor.initialize();
+        return executor;
+    }
+
+    /**
      * AI聊天专用线程池
      */
     @Bean(name = "aiChatExecutor")

--- a/oci-server/src/main/java/com/doubledimple/ociserver/job/AsyncJobRunner.java
+++ b/oci-server/src/main/java/com/doubledimple/ociserver/job/AsyncJobRunner.java
@@ -1,0 +1,44 @@
+package com.doubledimple.ociserver.job;
+
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * 短间隔 Quartz 任务的异步执行器。
+ * Quartz 工作线程只需调用 {@link #runOnce} 即可立即返回（方法是 @Async），真正的工作放到
+ * 专用线程池 jobExecutor 上执行，因此绝不会阻塞 Quartz 调度线程。
+ * 同时按任务名做单飞守卫：上一轮还没结束时，本轮直接跳过，避免在小机器上多轮堆积。
+ */
+@Slf4j
+@Component
+public class AsyncJobRunner {
+
+    private final Map<String, AtomicBoolean> locks = new ConcurrentHashMap<>();
+
+    @Async("jobExecutor")
+    public void runOnce(String name, Runnable task) {
+        AtomicBoolean lock = locks.computeIfAbsent(name, k -> new AtomicBoolean(false));
+        if (!lock.compareAndSet(false, true)) {
+            log.warn("[{}] 上一轮尚未结束，跳过本轮", name);
+            return;
+        }
+        MDC.put("traceId", UUID.randomUUID().toString().replace("-", ""));
+        long start = System.currentTimeMillis();
+        try {
+            task.run();
+        } catch (Exception e) {
+            log.error("[{}] 执行失败: {}", name, e.getMessage(), e);
+        } finally {
+            lock.set(false);
+            log.debug("[{}] 本轮结束，耗时 {} ms", name, System.currentTimeMillis() - start);
+            MDC.clear();
+        }
+    }
+}

--- a/oci-server/src/main/java/com/doubledimple/ociserver/job/CheckOfflineInstanceJob.java
+++ b/oci-server/src/main/java/com/doubledimple/ociserver/job/CheckOfflineInstanceJob.java
@@ -1,43 +1,31 @@
 package com.doubledimple.ociserver.job;
 
 import com.doubledimple.ocimonitor.service.MonitorCoreService;
-import lombok.extern.slf4j.Slf4j;
 import org.quartz.DisallowConcurrentExecution;
 import org.quartz.Job;
 import org.quartz.JobExecutionContext;
-import org.quartz.JobExecutionException;
-import org.slf4j.MDC;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import java.util.UUID;
-
 /**
- * 抢机调度器Job
+ * 探针离线检查Job
+ * 派发到异步线程池执行，不阻塞 Quartz 线程；上一轮未结束则跳过本轮。
  */
-@Slf4j
 @Component
 @DisallowConcurrentExecution
 public class CheckOfflineInstanceJob implements Job {
 
     private final MonitorCoreService monitorCoreService;
+    private final AsyncJobRunner asyncJobRunner;
 
     @Autowired
-    public CheckOfflineInstanceJob(MonitorCoreService monitorCoreService) {
+    public CheckOfflineInstanceJob(MonitorCoreService monitorCoreService, AsyncJobRunner asyncJobRunner) {
         this.monitorCoreService = monitorCoreService;
+        this.asyncJobRunner = asyncJobRunner;
     }
 
     @Override
-    public void execute(JobExecutionContext context) throws JobExecutionException {
-        String traceId = UUID.randomUUID().toString().replace("-", "");
-        MDC.put("traceId", traceId);
-        try {
-            log.debug("Start executing monitor check offLine....");
-            monitorCoreService.checkOfflineInstances();
-        } catch (Exception e) {
-            log.error("Start executing monitor check offLine error: {}", e.getMessage(), e);
-        } finally {
-            MDC.clear();
-        }
+    public void execute(JobExecutionContext context) {
+        asyncJobRunner.runOnce("monitor-offline-check", monitorCoreService::checkOfflineInstances);
     }
 }

--- a/oci-server/src/main/java/com/doubledimple/ociserver/job/MonitorFlashHeartbeatJob.java
+++ b/oci-server/src/main/java/com/doubledimple/ociserver/job/MonitorFlashHeartbeatJob.java
@@ -1,43 +1,31 @@
 package com.doubledimple.ociserver.job;
 
 import com.doubledimple.ocimonitor.service.MonitorCoreService;
-import lombok.extern.slf4j.Slf4j;
 import org.quartz.DisallowConcurrentExecution;
 import org.quartz.Job;
 import org.quartz.JobExecutionContext;
-import org.quartz.JobExecutionException;
-import org.slf4j.MDC;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import java.util.UUID;
-
 /**
- * 抢机调度器Job
+ * 探针心跳刷库Job
+ * 派发到异步线程池执行，不阻塞 Quartz 线程；上一轮未结束则跳过本轮。
  */
-@Slf4j
 @Component
 @DisallowConcurrentExecution
 public class MonitorFlashHeartbeatJob implements Job {
 
     private final MonitorCoreService monitorCoreService;
+    private final AsyncJobRunner asyncJobRunner;
 
     @Autowired
-    public MonitorFlashHeartbeatJob(MonitorCoreService monitorCoreService) {
+    public MonitorFlashHeartbeatJob(MonitorCoreService monitorCoreService, AsyncJobRunner asyncJobRunner) {
         this.monitorCoreService = monitorCoreService;
+        this.asyncJobRunner = asyncJobRunner;
     }
 
     @Override
-    public void execute(JobExecutionContext context) throws JobExecutionException {
-        String traceId = UUID.randomUUID().toString().replace("-", "");
-        MDC.put("traceId", traceId);
-        try {
-            log.debug("Start executing monitor flash heat beat....");
-            monitorCoreService.flushHeartbeatToDB();
-        } catch (Exception e) {
-            log.error("Start executing monitor flash heat beat error: {}", e.getMessage(), e);
-        } finally {
-            MDC.clear();
-        }
+    public void execute(JobExecutionContext context) {
+        asyncJobRunner.runOnce("monitor-heartbeat", monitorCoreService::flushHeartbeatToDB);
     }
 }

--- a/oci-server/src/main/java/com/doubledimple/ociserver/job/PingConnTimeJob.java
+++ b/oci-server/src/main/java/com/doubledimple/ociserver/job/PingConnTimeJob.java
@@ -1,44 +1,31 @@
 package com.doubledimple.ociserver.job;
 
-import com.doubledimple.ociserver.config.task.DynamicDailyTask;
 import com.doubledimple.ociserver.config.task.PingConnTimeTask;
-import lombok.extern.slf4j.Slf4j;
 import org.quartz.DisallowConcurrentExecution;
 import org.quartz.Job;
 import org.quartz.JobExecutionContext;
-import org.quartz.JobExecutionException;
-import org.slf4j.MDC;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import java.util.UUID;
-
 /**
- * 抢机调度器Job
+ * VPS Ping 探测Job
+ * 派发到异步线程池执行，不阻塞 Quartz 线程；上一轮未结束则跳过本轮。
  */
-@Slf4j
 @Component
 @DisallowConcurrentExecution
 public class PingConnTimeJob implements Job {
 
     private final PingConnTimeTask pingConnTimeTask;
+    private final AsyncJobRunner asyncJobRunner;
 
     @Autowired
-    public PingConnTimeJob(PingConnTimeTask pingConnTimeTask) {
+    public PingConnTimeJob(PingConnTimeTask pingConnTimeTask, AsyncJobRunner asyncJobRunner) {
         this.pingConnTimeTask = pingConnTimeTask;
+        this.asyncJobRunner = asyncJobRunner;
     }
 
     @Override
-    public void execute(JobExecutionContext context) throws JobExecutionException {
-        String traceId = UUID.randomUUID().toString().replace("-", "");
-        MDC.put("traceId", traceId);
-        try {
-            log.debug("开始执行ping测试");
-            pingConnTimeTask.pingConnTime();
-        } catch (Exception e) {
-            log.error("执行ping 测试失败: {}", e.getMessage(), e);
-        }finally {
-            MDC.clear();
-        }
+    public void execute(JobExecutionContext context) {
+        asyncJobRunner.runOnce("ping-conn-time", pingConnTimeTask::pingConnTime);
     }
 }


### PR DESCRIPTION
## 背景
延续 #165(流量任务异步化)的思路:**短间隔的 Quartz 任务一律改成「立即异步派发 + 单飞守卫 + 不阻塞 Quartz 线程」**,避免在小机器上因单轮耗时过长被 `@DisallowConcurrentExecution` + misfire 挡掉而漏跑。

## 现状排查结论
| Job | 频率 | 是否在 Quartz 线程同步等慢 I/O | 处理 |
|---|---|---|---|
| CreateInstanceJob | 6s | 否——已 `submit` 到隔离池 + 非阻塞超时 | ✅ 已是该模式,不改 |
| MonitorFlashHeartbeatJob | 15s | 是(逐条写库) | 本次改 |
| CheckOfflineInstanceJob | 60s | 轻(查询+日志),为一致性纳入 | 本次改 |
| PingConnTimeJob | 5min | **是**——`allOf().join()` 等整批 + 任务内同步发 Telegram | 本次改 |
| CheckLiveJob | 每小时 | 重活每天一次,非短间隔 | 暂不改 |

## 改动
- 新增 **`AsyncJobRunner`**:`@Async("jobExecutor")` 的 `runOnce(name, Runnable)`,按任务名用 `AtomicBoolean` 做**单飞守卫**(上一轮没结束就跳过本轮并打日志),带 MDC traceId。
- 新增专用 **`jobExecutor`**(core/max=3、queue=2、`DiscardPolicy`、不等待关机)。**刻意不用 `CallerRunsPolicy`**,确保线程占满时直接丢弃本次触发,绝不回灌到 Quartz 调度线程。
- `MonitorFlashHeartbeatJob` / `CheckOfflineInstanceJob` / `PingConnTimeJob` 改为 `execute()` 里调用 `asyncJobRunner.runOnce(...)` 后**立即返回**。
- `CreateInstanceJob` 未改(它本就是派发到独立池 + 非阻塞超时的范本)。

## 效果
Quartz 工作线程不再被这些任务长时间占用 → 不再因单轮超时/线程被占而 misfire/漏跑;真正的工作在 `jobExecutor` 上单飞执行,忙时"跳过本轮"(有日志、可预期)。

## 说明
- `PingConnTimeTask` / `MonitorCoreService` 内部逻辑未改,只是改变了"由谁、在哪个线程"调用,行为等价。
- 与 #165 都改了 `ThreadPoolConfig`,但新增的 bean 位置不同(本 PR 的 `jobExecutor` 在 `instanceTaskExecutor` 之后),合并时应无冲突。

## 测试
- [x] `mvn -pl oci-server -am compile` 编译通过(JDK21 环境临时用兼容 Lombok 验证,**仓库内 Lombok 版本未改动**)。
- [ ] 部署后观察:三个任务在 `job-async-*` 线程执行,Quartz 线程不再被占;小机器上忙时出现"跳过本轮"日志而非长期缺失。
---