### PR TITLE
fix: 抢机任务单飞与 key 释放，修复任务多时部分永久不执行

### DIFF
--- a/oci-server/src/main/java/com/doubledimple/ociserver/config/task/CreateInstanceTaskV2.java
+++ b/oci-server/src/main/java/com/doubledimple/ociserver/config/task/CreateInstanceTaskV2.java
@@ -170,7 +170,13 @@ public class CreateInstanceTaskV2 {
             log.debug("去重后剩余 {} 个任务", dedupedTasks.size());
 
             for (BootInstance task : dedupedTasks.values()) {
-                taskExecutor.submit(() -> processTask(task));
+                try {
+                    taskExecutor.submit(() -> processTask(task));
+                } catch (Exception e) {
+                    // 提交失败(如线程池已关闭)必须释放已占用的 key，否则该 key 永久泄漏
+                    log.error("提交任务失败，释放占用 - taskId: {}", task.getBootId(), e);
+                    removeTaskKey(task);
+                }
             }
 
             long endTime = System.currentTimeMillis();
@@ -203,14 +209,11 @@ public class CreateInstanceTaskV2 {
                     task.getArchitecture();
 
             if (activeTaskKeyMap.containsKey(key)) {
-                String mainBootId = activeTaskKeyMap.get(key);
-
-                if (task.getBootId().equals(mainBootId)) {
-                    dedupedTasks.put(key, task);
-                    log.debug("Key {} 已被任务 {} 占用，本轮继续执行它", key, mainBootId);
-                } else {
-                    log.debug("Key {} 已被任务 {} 占用，跳过替补任务 {}", key, mainBootId, task.getBootId());
-                }
+                // key 被占用 = 该(账号+区域+架构)已有一个抢机在飞，本轮一律跳过。
+                // 包括 holder 自己也要跳过：否则会对同一任务并发发起抢机，并在其中一个完成时
+                // 提前释放 key，破坏单飞。等在飞任务结束释放 key 后，下一轮再重新调度。
+                log.debug("Key {} 已被任务 {} 占用，本轮跳过任务 {}",
+                        key, activeTaskKeyMap.get(key), task.getBootId());
                 continue;
             }
 
@@ -555,21 +558,17 @@ public class CreateInstanceTaskV2 {
      */
     public void removeTaskKey(BootInstance task) {
         try {
-            if (task == null) return;
+            if (task == null || task.getBootId() == null) return;
 
-            Tenant tenant = tenantRepository.findById(task.getTenantId()).orElse(null);
-            if (tenant == null) return;
-            String key = tenant.getTenancy() + "_" +
-                    tenant.getRegion() + "_" +
-                    task.getArchitecture();
-            String existBootId = activeTaskKeyMap.get(key);
-            if (existBootId != null && existBootId.equals(task.getBootId())) {
-                activeTaskKeyMap.remove(key);
-                log.debug("释放占用: Key={} -> TaskId={}", key, task.getBootId());
-            } else {
-                log.debug("Key {} 当前未被任务 {} 占用，无需释放", key, task.getBootId());
+            // 按持有者 bootId 释放，不再重新查询租户重建 key：
+            // 1) 租户被删/查询失败时也能正常释放，避免 key 永久泄漏导致该(账号+区域+架构)永远被跳过；
+            // 2) 省去每次释放都要做的一次 DB 查询。
+            // 一个 bootId 至多持有一个 key，只移除“值 == 该 bootId”的条目，不会误删别的任务占用的 key。
+            boolean removed = activeTaskKeyMap.entrySet()
+                    .removeIf(e -> task.getBootId().equals(e.getValue()));
+            if (removed) {
+                log.debug("释放占用 - TaskId={}", task.getBootId());
             }
-
         } catch (Exception e) {
             log.error("释放 key 失败", e);
         }


### PR DESCRIPTION
## 背景
排查"抢机任务多时，部分任务长期/永久不执行"。大部分是**正常的去重 + 批量上限 + 抢机本身慢导致的排队**，但有几个会让"延迟"变成"永久不跑"的真实问题，本 PR 修复其中低风险、确定的三处（均在 `CreateInstanceTaskV2`）。

## 改动
1. **单飞 re-entry（去重逻辑）**：原 `deduplicateTasks` 中"key 已被同一 bootId 占用 → 本轮继续执行它"会对同一 `(账号+区域+架构)` **并发再发起一次抢机**，且其中一个完成时 `removeTaskKey` 会**提前释放 key**，使替补任务在前一个还在飞时就开跑，彻底破坏单飞。改为 **key 被占用时一律跳过**（含 holder 自身），等在飞任务结束释放 key 后下一轮再调度。

2. **`removeTaskKey` 的 key 永久泄漏 + 每次释放查库**：原实现靠 `tenantRepository.findById` 重新查租户来重建 key，租户被删/查询失败时直接 `return` **不释放** → 该 `(账号+区域+架构)` 之后被去重**永久跳过**（要重启才恢复）。改为**按持有者 bootId 直接从 map 中移除**（`removeIf(value == bootId)`），不再依赖租户、也省去每次释放的一次 DB 查询；一个 bootId 至多持有一个 key，只删值等于该 bootId 的条目，不会误删他人占用。

3. **提交失败导致 key 泄漏**：`taskExecutor.submit(...)` 包 try/catch，提交失败（如线程池关闭）时 `removeTaskKey` 释放已占用的 key。

## 暂未纳入（需更大/更敏感的改动，建议单独做）
- **超时不取消在飞的 OCI 调用**：超时后子任务若才创建成功，会变成"孤儿/不登记"。正确做法要重构 `executeGrabTaskAsync` 处理"超时后才成功"的并发回收，改动敏感，建议单独 PR 并仔细评审。
- **去重在 LIMIT 之后 → 同 key 替补任务挤占 BATCH_SIZE 名额、饿死其它账号**：可在查询里直接按 key 去重。项目用的是 **H2**（支持 `ROW_NUMBER()` 窗口函数），所以 SQL 级去重是可行的；唯一前提是确认 `(tenant_id, architecture)` 与业务去重键 `(tenancy, region, architecture)` 等价（即不存在同 `tenancy+region` 的重复租户行）。确认后可单独提交。

## 测试
- [x] `mvn -pl oci-server -am compile` 编译通过（JDK21 环境临时用兼容 Lombok 验证，**仓库内 Lombok 版本未改动**）。
- [ ] 部署后观察：`activeKeyCount`（`getSystemStatus`）不再出现"只增不减/卡住"；任务多时不再有账号长期不执行；日志不再出现同任务并发抢机/"任务正在执行中"误报。
---