### PR TITLE
fix: 抢机取数按 (tenant_id, architecture) 去重，避免任务多时部分账号被挤占

### DIFF
--- a/oci-dao/src/main/java/com/doubledimple/dao/repository/BootInstanceRepository.java
+++ b/oci-dao/src/main/java/com/doubledimple/dao/repository/BootInstanceRepository.java
@@ -90,6 +90,26 @@ public interface BootInstanceRepository extends JpaRepository<BootInstance, Long
             @Param("currentTime") Timestamp currentTime,
             @Param("limit") int limit);
 
+    /**
+     * 查询到期任务，并按 (tenant_id, architecture) 去重：每组只取最早到期的一条。
+     * 避免"同一账号+架构有大量重复任务时挤占 LIMIT 名额、饿死其它账号"的问题。
+     * （同组若 next_execution_time 完全相同出现并列，由调用方的内存去重再兜一层）
+     */
+    @Query(value = "SELECT * FROM BOOT_INSTANCE b " +
+            "WHERE b.status = 1 AND b.next_execution_time <= :currentTime " +
+            "AND b.next_execution_time = (" +
+            "    SELECT MIN(b2.next_execution_time) FROM BOOT_INSTANCE b2 " +
+            "    WHERE b2.status = 1 " +
+            "      AND b2.tenant_id = b.tenant_id " +
+            "      AND COALESCE(b2.architecture, '') = COALESCE(b.architecture, '') " +
+            "      AND b2.next_execution_time <= :currentTime) " +
+            "ORDER BY b.next_execution_time ASC " +
+            "LIMIT :limit",
+            nativeQuery = true)
+    List<BootInstance> findDistinctTasksToExecute(
+            @Param("currentTime") Timestamp currentTime,
+            @Param("limit") int limit);
+
 
     /**
     * @Description: 查询状态为1的

--- a/oci-server/src/main/java/com/doubledimple/ociserver/config/task/CreateInstanceTaskV2.java
+++ b/oci-server/src/main/java/com/doubledimple/ociserver/config/task/CreateInstanceTaskV2.java
@@ -145,7 +145,8 @@ public class CreateInstanceTaskV2 {
             long startTime = System.currentTimeMillis();
             Timestamp currentTime = new Timestamp(startTime);
 
-            List<BootInstance> expiredTasks = instanceRepository.findTasksToExecute(
+            // 按 (tenant_id, architecture) 去重后再取 BATCH_SIZE，避免同账号大量重复任务挤占名额、饿死其它账号
+            List<BootInstance> expiredTasks = instanceRepository.findDistinctTasksToExecute(
                     currentTime,
                     BATCH_SIZE
             );


### PR DESCRIPTION
## 问题
抢机任务多时，部分账号长期排不上、像是"不执行"。

## 根因
`checkAndExecuteTasksOnce` 用 `findTasksToExecute(now, BATCH_SIZE)`：只按 `next_execution_time` 取最老的 `BATCH_SIZE` 条，**去重是在内存里、LIMIT 之后**做的。于是同一账号/架构下的大量重复任务会**挤占 BATCH_SIZE 名额**，把稍微新一点、但属于其它账号的任务挤出本轮 → 其它账号被饿死。

## 改动
新增 `BootInstanceRepository.findDistinctTasksToExecute`：在 SQL 里按 `(tenant_id, architecture)` 取**每组最早到期的一条**，再 `ORDER BY next_execution_time ASC LIMIT :limit`；`checkAndExecuteTasksOnce` 改用它。这样每轮取到的就是 `BATCH_SIZE` 个**不同 (账号+区域+架构)** 的任务，不再被同组重复任务挤占。

```sql
SELECT * FROM BOOT_INSTANCE b
WHERE b.status = 1 AND b.next_execution_time <= :currentTime
  AND b.next_execution_time = (
      SELECT MIN(b2.next_execution_time) FROM BOOT_INSTANCE b2
      WHERE b2.status = 1 AND b2.tenant_id = b.tenant_id
        AND COALESCE(b2.architecture,'') = COALESCE(b.architecture,'')
        AND b2.next_execution_time <= :currentTime)
ORDER BY b.next_execution_time ASC LIMIT :limit
```

## 为什么 (tenant_id, architecture) 与原 (tenancy, region, architecture) 等价
- `BootInstance` **没有 region 字段**，区域完全来自 Tenant 行；原内存去重的 region 就是 `tenantMap.get(task.getTenantId()).getRegion()` —— **region 是 tenant_id 的函数**。
- `Tenant` 一行 = 一个 `(tenancy, region)`；多区账号 = 多个 Tenant 行 = **多个不同的 tenant_id**。
- 因此按 `tenant_id` 分组天然把"同账号不同区域"分开（各自独立并发），同区域内再靠 `architecture` 把 AMD/ARM 分开（各自并发）。与原键完全一致。

## 说明
- 同组若 `next_execution_time` 完全相同出现并列，会返回多条，由调用方原有的内存去重（`activeTaskKeyMap`）再兜一层，不会重复抢机。
- 与 #168 都改了 `CreateInstanceTaskV2`，但本 PR 只改 `checkAndExecuteTasksOnce` 里取数那一行，#168 改的是提交循环/去重分支/`removeTaskKey`，**不同位置，合并应无冲突**。本 PR 不含 #168 的单飞/泄漏修复，建议两者一起合并。

## 测试
- [x] `mvn -pl oci-server -am compile` 编译通过（JDK21 环境临时用兼容 Lombok 验证，**仓库内 Lombok 未改动**）。
- [ ] H2 运行期验证该 native SQL（窗口函数未用，纯相关子查询 + COALESCE，H2/通用 SQL 均可）；多账号多任务下确认各账号都能轮到、同账号 AMD/ARM 仍并发。
---