### PR TITLE
fix star history chart

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -272,7 +272,7 @@ Thanks to everyone who has supported this project. The donation QR code is avail
 
 <div align="center">
 
-[![Star History Chart](https://api.star-history.com/svg?repos=doubleDimple/oci-start&type=Date)](https://star-history.com/#doubleDimple/oci-start&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=doubleDimple/oci-start&type=Date)](https://star-history.dera.page/#doubleDimple/oci-start&type=Date)
 
 </div>
 

--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ location ~ ^/websockify/(\d+)$ {
 
 <div align="center">
 
-[![Star History Chart](https://api.star-history.com/svg?repos=doubleDimple/oci-start&type=Date)](https://star-history.com/#doubleDimple/oci-start&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=doubleDimple/oci-start&type=Date)](https://star-history.dera.page/#doubleDimple/oci-start&type=Date)
 
 </div>
 


### PR DESCRIPTION
The star history chart is currently broken due to GitHub stargazer API restrictions. This change switches the chart to star-history.dera.page, restoring a working and reliable star history chart.